### PR TITLE
[TS-238]Feat: 진행중인 습관 생성 api 작성

### DIFF
--- a/src/main/java/connectingstar/tars/common/exception/errorcode/HabitErrorCode.java
+++ b/src/main/java/connectingstar/tars/common/exception/errorcode/HabitErrorCode.java
@@ -1,0 +1,34 @@
+package connectingstar.tars.common.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+/**
+ * 습관 관련 에러 코드
+ *
+ * @author 송병선
+ */
+
+@Getter
+@RequiredArgsConstructor
+public enum HabitErrorCode implements ErrorCode {
+
+    /**
+     * empty
+     */
+    RUN_HABIT_PARAM_IDENTITY_EMPTY(HttpStatus.BAD_REQUEST, "진행중인 습관 정체성은 필수 입력값입니다."),
+    RUN_HABIT_PARAM_RUN_TIME_EMPTY(HttpStatus.BAD_REQUEST, "진행중인 습관 실천 시간은 필수 입력값입니다."),
+    RUN_HABIT_PARAM_PLACE_EMPTY(HttpStatus.BAD_REQUEST, "진행중인 습관 장소는 필수 입력값입니다."),
+    RUN_HABIT_PARAM_ACTION_EMPTY(HttpStatus.BAD_REQUEST, "진행중인 습관 행동은 필수 입력값입니다"),
+    RUN_HABIT_PARAM_VALUE_EMPTY(HttpStatus.BAD_REQUEST, "진행중인 습관 수량(얼마나)은 필수 입력값입니다"),
+    RUN_HABIT_PARAM_UNIT_EMPTY(HttpStatus.BAD_REQUEST, "진행중인 습관 단위는 필수 입력값입니다"),
+
+    /**
+     * not found
+     */
+    ALERT_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "입력된 알람 차수를 찾을 수 없습니다");
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/connectingstar/tars/habit/command/RunHabitCommandService.java
+++ b/src/main/java/connectingstar/tars/habit/command/RunHabitCommandService.java
@@ -1,0 +1,84 @@
+package connectingstar.tars.habit.command;
+
+import connectingstar.tars.common.exception.ValidationException;
+import connectingstar.tars.habit.domain.HabitAlert;
+import connectingstar.tars.habit.domain.RunHabit;
+import connectingstar.tars.habit.repository.HabitAlertRepository;
+import connectingstar.tars.habit.repository.RunHabitRepository;
+import connectingstar.tars.habit.request.RunHabitPostRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalTime;
+
+import static connectingstar.tars.common.exception.errorcode.HabitErrorCode.ALERT_ORDER_NOT_FOUND;
+
+/**
+ * 진행중인 습관의 상태를 변경하는 요청을 처리하는 서비스 클래스
+ *
+ * @author 김성수
+ */
+
+@RequiredArgsConstructor
+@Service
+public class RunHabitCommandService {
+
+    public static final int FIRST_ALERT_STATUS = 1;
+    public static final boolean ALERT_ON = true;
+    public static final int FIRST_ALERT_DEFAULT = 10;
+    public static final int SECOND_ALERT_STATUS = 2;
+    public static final int SECOND_ALERT_DEFAULT = 30;
+
+    private final RunHabitRepository runHabitRepository;
+    private final HabitAlertRepository habitAlertRepository;
+
+    /**
+     * 진행중인 습관 생성
+     *
+     * @param param {@link RunHabitPostRequest}
+     */
+    public RunHabit postRunHabit(RunHabitPostRequest param) {
+        RunHabit runHabit = RunHabit.postRunHabit()
+                .identity(param.getIdentity())
+                .runTime(param.getRunTime())
+                .place(param.getPlace())
+                .action(param.getAction())
+                .value(param.getValue())
+                .unit(param.getUnit())
+                .build();
+        HabitAlert firstHabitAlert = makeAlert(runHabit, param.getRunTime(), param.getFirstAlert(), FIRST_ALERT_STATUS);
+        HabitAlert secondHabitAlert = makeAlert(runHabit, param.getRunTime(), param.getSecondAlert(), SECOND_ALERT_STATUS);
+        runHabit.updateAlert(habitAlertRepository.save(firstHabitAlert));
+        runHabit.updateAlert(habitAlertRepository.save(secondHabitAlert));
+        return runHabitRepository.save(runHabit);
+
+    }
+
+    private HabitAlert makeAlert(RunHabit runHabit,LocalTime runTime, LocalTime alert, int alertStatus) {
+        if(alert != null){
+            return HabitAlert.postHabitAlert()
+                    .runHabit(runHabit)
+                    .alertOrder(alertStatus)
+                    .alertTime(alert)
+                    .alertStatus(ALERT_ON)
+                    .build();
+        } else {
+            return HabitAlert.postHabitAlert()
+                    .runHabit(runHabit)
+                    .alertOrder(alertStatus)
+                    .alertTime(changeTime(runTime,alertStatus))
+                    .alertStatus(ALERT_ON)
+                    .build();
+        }
+    }
+
+    private LocalTime changeTime(LocalTime runTime, int alertStatus) {
+        if(alertStatus == FIRST_ALERT_STATUS){
+            return runTime.minusMinutes(FIRST_ALERT_DEFAULT);
+        } else if(alertStatus == SECOND_ALERT_STATUS){
+            return runTime.plusMinutes(SECOND_ALERT_DEFAULT);
+        }
+        throw new ValidationException(ALERT_ORDER_NOT_FOUND);
+    }
+
+}

--- a/src/main/java/connectingstar/tars/habit/controller/HabitController.java
+++ b/src/main/java/connectingstar/tars/habit/controller/HabitController.java
@@ -1,0 +1,34 @@
+package connectingstar.tars.habit.controller;
+
+import connectingstar.tars.habit.command.RunHabitCommandService;
+import connectingstar.tars.habit.request.RunHabitPostRequest;
+import connectingstar.tars.habit.validation.HabitValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 진행중인 습관 관련 API
+ *
+ *  @author 김성수
+ */
+@RequiredArgsConstructor
+@RequestMapping(value = "/habit", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class HabitController {
+
+    private final RunHabitCommandService runHabitCommandService;
+
+    @PostMapping(value = "/")
+    public ResponseEntity<?> postRunHabit(@RequestBody RunHabitPostRequest param) {
+        HabitValidator.validate(param);
+        runHabitCommandService.postRunHabit(param);
+
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/connectingstar/tars/habit/domain/HabitAlert.java
+++ b/src/main/java/connectingstar/tars/habit/domain/HabitAlert.java
@@ -2,6 +2,7 @@ package connectingstar.tars.habit.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -52,4 +53,12 @@ public class HabitAlert {
      */
     @Column(name = "alert_status", nullable = false)
     private Boolean alertStatus;
+
+    @Builder(builderMethodName = "postHabitAlert")
+    public HabitAlert(RunHabit runHabit, Integer alertOrder, LocalTime alertTime, Boolean alertStatus) {
+        this.runHabit = runHabit;
+        this.alertOrder = alertOrder;
+        this.alertTime = alertTime;
+        this.alertStatus = alertStatus;
+    }
 }

--- a/src/main/java/connectingstar/tars/habit/domain/HabitAlert.java
+++ b/src/main/java/connectingstar/tars/habit/domain/HabitAlert.java
@@ -1,12 +1,12 @@
-package connectingstar.tars.habit.habitalert.domain;
+package connectingstar.tars.habit.domain;
 
-import connectingstar.tars.habit.runhabit.domain.RunHabit;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 /**
  * 습관 알림(1차, 2차)
@@ -45,7 +45,7 @@ public class HabitAlert {
      * 알림 시간
      */
     @Column(name = "alert_time", nullable = false)
-    private LocalDateTime alertTime;
+    private LocalTime alertTime;
 
     /**
      * 알림 여부

--- a/src/main/java/connectingstar/tars/habit/domain/HabitHistory.java
+++ b/src/main/java/connectingstar/tars/habit/domain/HabitHistory.java
@@ -1,6 +1,6 @@
-package connectingstar.tars.habit.habithistory.domain;
+package connectingstar.tars.habit.domain;
 
-import connectingstar.tars.habit.runhabit.domain.RunHabit;
+import connectingstar.tars.habit.domain.RunHabit;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/connectingstar/tars/habit/domain/QuitHabit.java
+++ b/src/main/java/connectingstar/tars/habit/domain/QuitHabit.java
@@ -1,33 +1,31 @@
-package connectingstar.tars.habit.runhabit.domain;
+package connectingstar.tars.habit.domain;
 
-import connectingstar.tars.habit.habitalert.domain.HabitAlert;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.time.LocalTime;
 
 /**
- * 진행중인습관 엔티티
+ * 종료한 습관 엔티티
  *
  * @author 김성수
  */
-
-@Entity
 @Getter
+@Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Access(AccessType.FIELD) //공부 필요
-public class RunHabit {
+@Access(AccessType.FIELD)
+public class QuitHabit {
 
     /**
-     * 진행중인 습관 ID
+     * 종료한 습관 ID
      */
     @Id
-    @Column(name = "run_habit_id", nullable = false)
+    @Column(name = "quit_habit_id", nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer runHabitId;
+    private Integer quitHabitId;
 
     /**
      * 사용자 PK
@@ -35,16 +33,10 @@ public class RunHabit {
     //TODO: USER Entity 추가 후 작성
 
     /**
-     * 정체성
-     */
-    @Column(name = "identity", nullable = false)
-    private String identity;
-
-    /**
      * 실천 시간
      */
     @Column(name = "run_time", nullable = false)
-    private LocalDateTime runTime;
+    private LocalTime runTime;
 
     /**
      * 장소
@@ -59,22 +51,33 @@ public class RunHabit {
     private String action;
 
     /**
-     * 얼마나
+     * 실천횟수
      */
     @Column(name = "value", nullable = false)
     private Integer value;
 
     /**
-     * 단위
+     * 실천횟수
      */
-    @Column(name = "unit", nullable = false)
-    private String unit;
+    @Column(name = "rest_value", nullable = false)
+    private Integer restValue;
 
     /**
-     * 알림들
+     * 종료 사유
      */
-    @OneToMany(mappedBy = "runHabit", fetch = FetchType.LAZY,cascade = {CascadeType.PERSIST,CascadeType.MERGE,CascadeType.REMOVE})
-    private List<HabitAlert> alerts;
+    @Column(name = "reason_of_quit", nullable = false)
+    private String reasonOfQuit;
 
+    /**
+     * 시작 날짜
+     */
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    /**
+     * 종료 날짜
+     */
+    @Column(name = "quit_date", nullable = false)
+    private LocalDateTime quitDate;
 
 }

--- a/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
+++ b/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
@@ -1,13 +1,13 @@
 package connectingstar.tars.habit.domain;
 
-import connectingstar.tars.habit.domain.HabitAlert;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -74,8 +74,25 @@ public class RunHabit {
     /**
      * 알림들
      */
-    @OneToMany(mappedBy = "runHabit", fetch = FetchType.LAZY,cascade = {CascadeType.PERSIST,CascadeType.MERGE,CascadeType.REMOVE})
-    private List<HabitAlert> alerts;
+    @OneToMany(mappedBy = "runHabit", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE})
+    private List<HabitAlert> alerts = new ArrayList<>();
 
+    @Builder(builderMethodName = "postRunHabit")
+    public RunHabit(String identity,
+                    LocalTime runTime,
+                    String place,
+                    String action,
+                    Integer value,
+                    String unit) {
+        this.identity = identity;
+        this.runTime = runTime;
+        this.place = place;
+        this.action = action;
+        this.value = value;
+        this.unit = unit;
+    }
 
+    public void updateAlert(HabitAlert habitAlert){
+        this.alerts.add(habitAlert);
+    }
 }

--- a/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
+++ b/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
@@ -1,30 +1,34 @@
-package connectingstar.tars.habit.quithabit.domain;
+package connectingstar.tars.habit.domain;
 
+import connectingstar.tars.habit.domain.HabitAlert;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 /**
- * 종료한 습관 엔티티
+ * 진행중인습관 엔티티
  *
  * @author 김성수
  */
-@Getter
+
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Access(AccessType.FIELD)
-public class QuitHabit {
+@Access(AccessType.FIELD) //공부 필요
+public class RunHabit {
 
     /**
-     * 종료한 습관 ID
+     * 진행중인 습관 ID
      */
     @Id
-    @Column(name = "quit_habit_id", nullable = false)
+    @Column(name = "run_habit_id", nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer quitHabitId;
+    private Integer runHabitId;
 
     /**
      * 사용자 PK
@@ -32,10 +36,16 @@ public class QuitHabit {
     //TODO: USER Entity 추가 후 작성
 
     /**
+     * 정체성
+     */
+    @Column(name = "identity", nullable = false)
+    private String identity;
+
+    /**
      * 실천 시간
      */
     @Column(name = "run_time", nullable = false)
-    private LocalDateTime runTime;
+    private LocalTime runTime;
 
     /**
      * 장소
@@ -50,33 +60,22 @@ public class QuitHabit {
     private String action;
 
     /**
-     * 실천횟수
+     * 얼마나
      */
     @Column(name = "value", nullable = false)
     private Integer value;
 
     /**
-     * 실천횟수
+     * 단위
      */
-    @Column(name = "rest_value", nullable = false)
-    private Integer restValue;
+    @Column(name = "unit", nullable = false)
+    private String unit;
 
     /**
-     * 종료 사유
+     * 알림들
      */
-    @Column(name = "reason_of_quit", nullable = false)
-    private String reasonOfQuit;
+    @OneToMany(mappedBy = "runHabit", fetch = FetchType.LAZY,cascade = {CascadeType.PERSIST,CascadeType.MERGE,CascadeType.REMOVE})
+    private List<HabitAlert> alerts;
 
-    /**
-     * 시작 날짜
-     */
-    @Column(name = "start_date", nullable = false)
-    private LocalDateTime startDate;
-
-    /**
-     * 종료 날짜
-     */
-    @Column(name = "quit_date", nullable = false)
-    private LocalDateTime quitDate;
 
 }

--- a/src/main/java/connectingstar/tars/habit/repository/HabitAlertRepository.java
+++ b/src/main/java/connectingstar/tars/habit/repository/HabitAlertRepository.java
@@ -1,0 +1,7 @@
+package connectingstar.tars.habit.repository;
+
+import connectingstar.tars.habit.domain.HabitAlert;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HabitAlertRepository extends JpaRepository<HabitAlert,Integer> {
+}

--- a/src/main/java/connectingstar/tars/habit/repository/RunHabitRepository.java
+++ b/src/main/java/connectingstar/tars/habit/repository/RunHabitRepository.java
@@ -1,0 +1,7 @@
+package connectingstar.tars.habit.repository;
+
+import connectingstar.tars.habit.domain.RunHabit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RunHabitRepository extends JpaRepository<RunHabit,Integer> {
+}

--- a/src/main/java/connectingstar/tars/habit/request/RunHabitPostRequest.java
+++ b/src/main/java/connectingstar/tars/habit/request/RunHabitPostRequest.java
@@ -1,0 +1,66 @@
+package connectingstar.tars.habit.request;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+/**
+ * 진행중인 습관 생성 요청
+ *
+ * @author 김성수
+ */
+@Getter
+@Setter
+public class RunHabitPostRequest {
+
+    /**
+     * 사용자 PK
+     */
+    //TODO: USER Entity 추가 후 작성
+
+    /**
+     * 정체성
+     */
+    private String identity;
+
+    /**
+     * 실천 시간
+     */
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime runTime;
+
+    /**
+     * 장소
+     */
+    private String place;
+
+    /**
+     * 행동
+     */
+    private String action;
+
+    /**
+     * 얼마나
+     */
+    private Integer value;
+
+    /**
+     * 단위
+     */
+    private String unit;
+
+    /**
+     * 1차 알림 (값이 없을 시 자동으로 runTime 10분 전으로 설정)
+     */
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime firstAlert;
+
+    /**
+     * 2차 알림 (값이 없을 시 자동으로 runTime 30분 후로 설정)
+     */
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime secondAlert;
+}

--- a/src/main/java/connectingstar/tars/habit/response/RunHabitPostResponse.java
+++ b/src/main/java/connectingstar/tars/habit/response/RunHabitPostResponse.java
@@ -1,0 +1,5 @@
+package connectingstar.tars.habit.response;
+
+public class RunHabitPostResponse {
+    //TODO: 입력값에 어떤게 들어가면 좋을지 추후 논의
+}

--- a/src/main/java/connectingstar/tars/habit/validation/HabitValidator.java
+++ b/src/main/java/connectingstar/tars/habit/validation/HabitValidator.java
@@ -1,0 +1,38 @@
+package connectingstar.tars.habit.validation;
+
+import connectingstar.tars.common.exception.ValidationException;
+import connectingstar.tars.common.exception.errorcode.ErrorCode;
+import connectingstar.tars.habit.request.RunHabitPostRequest;
+import lombok.experimental.UtilityClass;
+
+import java.util.Objects;
+
+import static connectingstar.tars.common.exception.errorcode.HabitErrorCode.*;
+
+
+/**
+ * 습관관련 요청 파라미터 검증
+ *
+ * @author 김성수
+ */
+@UtilityClass
+public class HabitValidator {
+
+    /**
+     * 진행중인 습관 생성 요청 검증
+     */
+    public void validate(RunHabitPostRequest param) {
+        validateNull(param.getIdentity(), RUN_HABIT_PARAM_IDENTITY_EMPTY);
+        validateNull(param.getRunTime(), RUN_HABIT_PARAM_RUN_TIME_EMPTY);
+        validateNull(param.getPlace(), RUN_HABIT_PARAM_PLACE_EMPTY);
+        validateNull(param.getAction(), RUN_HABIT_PARAM_ACTION_EMPTY);
+        validateNull(param.getValue(), RUN_HABIT_PARAM_VALUE_EMPTY);
+        validateNull(param.getUnit(), RUN_HABIT_PARAM_UNIT_EMPTY);
+    }
+
+    private void validateNull(Object param, ErrorCode errorCode) {
+        if (Objects.isNull(param)) {
+            throw new ValidationException(errorCode);
+        }
+    }
+}


### PR DESCRIPTION
일단 컨벤션을 따로 논의하지는 않았지만 통일하는 것이 좋다고 생각되어서 병선님의 코드를 참고하여 진행중인 습관 API를 작성했습니다.

기존에 엔티티별로 따로따로 나눠서 패키지 구조를 만들었는데 참고하는 과정에서 굳이 불필요하게 세부적으로 나눌 필요가 있을까? 결국 습관이라는 큰 틀안에서 구성되는건데? 라는 생각이 들어서 habit라는 패키지 아래에 전부 통합했습니다.

엔티티 내부에 있던 LocalDateTime도 굳이 Date가 필요없는 데이터들인데 Date가 들어있는게 불필요하단 생각이 들어서 LocalTime로 변경했습니다(날짜가 필요한건 수정하지 않은것도 있습니다.)

추가적으로 Service에서는 Builder 패턴을 이용해서 엔티티를 생성하고 진행중인 습관을 저장하도록 만들어 뒀습니다.
