### PR TITLE
TS-202Feat: 진행중인 습관 삭제 API 생성

### DIFF
--- a/src/main/java/connectingstar/tars/TarsApplication.java
+++ b/src/main/java/connectingstar/tars/TarsApplication.java
@@ -2,8 +2,10 @@ package connectingstar.tars;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TarsApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/connectingstar/tars/common/audit/Auditable.java
+++ b/src/main/java/connectingstar/tars/common/audit/Auditable.java
@@ -1,0 +1,28 @@
+package connectingstar.tars.common.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Auditable {
+    @CreatedDate
+    @Column(name = "created_at",updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}
+
+

--- a/src/main/java/connectingstar/tars/habit/controller/HabitController.java
+++ b/src/main/java/connectingstar/tars/habit/controller/HabitController.java
@@ -1,6 +1,7 @@
 package connectingstar.tars.habit.controller;
 
 import connectingstar.tars.habit.command.RunHabitCommandService;
+import connectingstar.tars.habit.request.RunHabitDeleteRequest;
 import connectingstar.tars.habit.request.RunHabitPostRequest;
 import connectingstar.tars.habit.request.RunHabitPutRequest;
 import connectingstar.tars.habit.validation.HabitValidator;
@@ -33,5 +34,11 @@ public class HabitController {
     @PutMapping(value = "/")
     public ResponseEntity<?> putRunHabit(@RequestBody RunHabitPutRequest param) {
         return ResponseEntity.ok(runHabitCommandService.putRunHabit(param));
+    }
+
+    @DeleteMapping(value = "/")
+    public ResponseEntity<?> deleteRunHabit(@RequestBody RunHabitDeleteRequest param) {
+        runHabitCommandService.deleteRunHabit(param);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/connectingstar/tars/habit/domain/HabitHistory.java
+++ b/src/main/java/connectingstar/tars/habit/domain/HabitHistory.java
@@ -1,5 +1,6 @@
 package connectingstar.tars.habit.domain;
 
+import connectingstar.tars.common.audit.Auditable;
 import connectingstar.tars.habit.domain.RunHabit;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Access(AccessType.FIELD)
-public class HabitHistory {
+public class HabitHistory extends Auditable {
 
     /**
      * 습관기록 데이터 ID

--- a/src/main/java/connectingstar/tars/habit/domain/QuitHabit.java
+++ b/src/main/java/connectingstar/tars/habit/domain/QuitHabit.java
@@ -1,7 +1,9 @@
 package connectingstar.tars.habit.domain;
 
+import connectingstar.tars.common.audit.Auditable;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,7 +19,7 @@ import java.time.LocalTime;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Access(AccessType.FIELD)
-public class QuitHabit {
+public class QuitHabit extends Auditable {
 
     /**
      * 종료한 습관 ID
@@ -57,7 +59,7 @@ public class QuitHabit {
     private Integer value;
 
     /**
-     * 실천횟수
+     * 휴식 실천횟수
      */
     @Column(name = "rest_value", nullable = false)
     private Integer restValue;
@@ -80,4 +82,15 @@ public class QuitHabit {
     @Column(name = "quit_date", nullable = false)
     private LocalDateTime quitDate;
 
+    @Builder(builderMethodName = "postQuitHabit")
+    public QuitHabit(LocalTime runTime, String place, String action, Integer value, Integer restValue, String reasonOfQuit, LocalDateTime startDate, LocalDateTime quitDate) {
+        this.runTime = runTime;
+        this.place = place;
+        this.action = action;
+        this.value = value;
+        this.restValue = restValue;
+        this.reasonOfQuit = reasonOfQuit;
+        this.startDate = startDate;
+        this.quitDate = quitDate;
+    }
 }

--- a/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
+++ b/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
@@ -73,6 +73,11 @@ public class RunHabit {
     private String unit;
 
     /**
+     * 습관 기록
+     */
+    @OneToMany(mappedBy = "runHabit", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE})
+    private List<HabitHistory> habitHistories = new ArrayList<>();
+    /**
      * 알림들
      */
     @OneToMany(mappedBy = "runHabit", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE})

--- a/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
+++ b/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
@@ -1,5 +1,6 @@
 package connectingstar.tars.habit.domain;
 
+import connectingstar.tars.common.audit.Auditable;
 import connectingstar.tars.habit.request.RunHabitPutRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -21,7 +22,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Access(AccessType.FIELD) //공부 필요
-public class RunHabit {
+public class RunHabit extends Auditable {
 
     /**
      * 진행중인 습관 ID

--- a/src/main/java/connectingstar/tars/habit/repository/HabitHistoryRepository.java
+++ b/src/main/java/connectingstar/tars/habit/repository/HabitHistoryRepository.java
@@ -1,0 +1,7 @@
+package connectingstar.tars.habit.repository;
+
+import connectingstar.tars.habit.domain.HabitHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HabitHistoryRepository extends JpaRepository<HabitHistory,Integer> {
+}

--- a/src/main/java/connectingstar/tars/habit/repository/QuitHabitRepository.java
+++ b/src/main/java/connectingstar/tars/habit/repository/QuitHabitRepository.java
@@ -1,0 +1,7 @@
+package connectingstar.tars.habit.repository;
+
+import connectingstar.tars.habit.domain.QuitHabit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuitHabitRepository extends JpaRepository<QuitHabit,Integer> {
+}

--- a/src/main/java/connectingstar/tars/habit/request/RunHabitDeleteRequest.java
+++ b/src/main/java/connectingstar/tars/habit/request/RunHabitDeleteRequest.java
@@ -1,0 +1,29 @@
+package connectingstar.tars.habit.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 진행중인 습관 삭제 요청
+ *
+ * @author 김성수
+ */
+@Getter
+@Setter
+public class RunHabitDeleteRequest {
+
+    /**
+     * 사용자 PK
+     */
+    //TODO: USER Entity 추가 후 작성
+
+    /**
+     * 진행중인 습관 ID
+     */
+    private Integer runHabitId;
+
+    /**
+     * 삭제 이유
+     */
+    private String reason;
+}


### PR DESCRIPTION
기존의 RunHabit에 HabitHistory와 양방향 매핑이 되어 있지 않아서 새로 추가했습니다
엔티티에 CreateAt, UpdateAt을 추가할 수 있는 Auditable클래스를 추가했습니다
진행중인 습관이 삭제되면 기존에 연관되어 있던 RunHabit과 해당 RunHabit이 가지고 있던 HabitHistory가 전부 지워지고 기록을 토대로 QuitHabit이 생성됩니다

UserId연동은 UserEntity만들어지면 그때 하겠습니다