### PR TITLE
TS-231 Feat: 지난 습관 조회 API 생성

### DIFF
--- a/src/main/java/connectingstar/tars/habit/controller/HabitController.java
+++ b/src/main/java/connectingstar/tars/habit/controller/HabitController.java
@@ -1,6 +1,8 @@
 package connectingstar.tars.habit.controller;
 
 import connectingstar.tars.habit.command.RunHabitCommandService;
+import connectingstar.tars.habit.query.QuitHabitQueryService;
+import connectingstar.tars.habit.request.QuitHabitListRequest;
 import connectingstar.tars.habit.request.RunHabitDeleteRequest;
 import connectingstar.tars.habit.request.RunHabitPostRequest;
 import connectingstar.tars.habit.request.RunHabitPutRequest;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class HabitController {
 
     private final RunHabitCommandService runHabitCommandService;
+    private final QuitHabitQueryService quitHabitQueryService;
 
     @PostMapping(value = "/")
     public ResponseEntity<?> postRunHabit(@RequestBody RunHabitPostRequest param) {
@@ -31,6 +34,12 @@ public class HabitController {
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
+
+    @GetMapping(value = "/quit/")
+    public ResponseEntity<?> getQuitHabitList(@RequestBody QuitHabitListRequest param) {
+        HabitValidator.validate(param);
+        return ResponseEntity.ok(quitHabitQueryService.getQuitHabitList(param));
+    }
     @PutMapping(value = "/")
     public ResponseEntity<?> putRunHabit(@RequestBody RunHabitPutRequest param) {
         return ResponseEntity.ok(runHabitCommandService.putRunHabit(param));

--- a/src/main/java/connectingstar/tars/habit/controller/HabitController.java
+++ b/src/main/java/connectingstar/tars/habit/controller/HabitController.java
@@ -26,7 +26,7 @@ public class HabitController {
     private final RunHabitCommandService runHabitCommandService;
     private final QuitHabitQueryService quitHabitQueryService;
 
-    @PostMapping(value = "/")
+    @PostMapping
     public ResponseEntity<?> postRunHabit(@RequestBody RunHabitPostRequest param) {
         HabitValidator.validate(param);
         runHabitCommandService.postRunHabit(param);
@@ -34,18 +34,18 @@ public class HabitController {
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
-
-    @GetMapping(value = "/quit/")
-    public ResponseEntity<?> getQuitHabitList(@RequestBody QuitHabitListRequest param) {
+    @GetMapping(value = "/quit")
+    public ResponseEntity<?> getQuitHabitList(QuitHabitListRequest param) {
         HabitValidator.validate(param);
         return ResponseEntity.ok(quitHabitQueryService.getQuitHabitList(param));
     }
-    @PutMapping(value = "/")
+
+    @PutMapping
     public ResponseEntity<?> putRunHabit(@RequestBody RunHabitPutRequest param) {
         return ResponseEntity.ok(runHabitCommandService.putRunHabit(param));
     }
 
-    @DeleteMapping(value = "/")
+    @DeleteMapping
     public ResponseEntity<?> deleteRunHabit(@RequestBody RunHabitDeleteRequest param) {
         runHabitCommandService.deleteRunHabit(param);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/src/main/java/connectingstar/tars/habit/domain/HabitHistory.java
+++ b/src/main/java/connectingstar/tars/habit/domain/HabitHistory.java
@@ -2,8 +2,10 @@ package connectingstar.tars.habit.domain;
 
 import connectingstar.tars.common.audit.Auditable;
 import connectingstar.tars.habit.domain.RunHabit;
+import connectingstar.tars.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,12 +34,14 @@ public class HabitHistory extends Auditable {
     /**
      * 사용자 PK
      */
-    //TODO: USER Entity 추가 후 작성
+    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST,CascadeType.MERGE} )
+    @JoinColumn(name = "user_id",nullable = false)
+    private User user;
 
     /**
      * 습관 PK
      */
-    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST,CascadeType.MERGE,CascadeType.REMOVE} )
+    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST,CascadeType.MERGE} )
     @JoinColumn(name = "run_habit_id",nullable = false)
     private RunHabit runHabit;
 
@@ -78,4 +82,16 @@ public class HabitHistory extends Auditable {
     @Column(name = "is_rest",nullable = false)
     private Boolean isRest;
 
+    @Builder
+    public HabitHistory(Integer habitHistoryId, User user, RunHabit runHabit, Integer achievement, String review, LocalDateTime runDate, String runPlace, String runValue, Boolean isRest) {
+        this.habitHistoryId = habitHistoryId;
+        this.user = user;
+        this.runHabit = runHabit;
+        this.achievement = achievement;
+        this.review = review;
+        this.runDate = runDate;
+        this.runPlace = runPlace;
+        this.runValue = runValue;
+        this.isRest = isRest;
+    }
 }

--- a/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
+++ b/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
@@ -2,6 +2,7 @@ package connectingstar.tars.habit.domain;
 
 import connectingstar.tars.common.audit.Auditable;
 import connectingstar.tars.habit.request.RunHabitPutRequest;
+import connectingstar.tars.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -35,7 +36,9 @@ public class RunHabit extends Auditable {
     /**
      * 사용자 PK
      */
-    //TODO: USER Entity 추가 후 작성
+    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST,CascadeType.MERGE} )
+    @JoinColumn(name = "user_id",nullable = false)
+    private User user;
 
     /**
      * 정체성
@@ -76,7 +79,7 @@ public class RunHabit extends Auditable {
     /**
      * 습관 기록
      */
-    @OneToMany(mappedBy = "runHabit", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE})
+    @OneToMany(mappedBy = "runHabit", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<HabitHistory> habitHistories = new ArrayList<>();
     /**
      * 알림들
@@ -86,11 +89,13 @@ public class RunHabit extends Auditable {
 
     @Builder(builderMethodName = "postRunHabit")
     public RunHabit(String identity,
+                    User user,
                     LocalTime runTime,
                     String place,
                     String action,
                     Integer value,
                     String unit) {
+        this.user = user;
         this.identity = identity;
         this.runTime = runTime;
         this.place = place;

--- a/src/main/java/connectingstar/tars/habit/repository/QuitHabitDao.java
+++ b/src/main/java/connectingstar/tars/habit/repository/QuitHabitDao.java
@@ -1,0 +1,67 @@
+package connectingstar.tars.habit.repository;
+
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import connectingstar.tars.constellation.domain.QConstellation;
+import connectingstar.tars.constellation.response.ConstellationListResponse;
+import connectingstar.tars.habit.domain.QQuitHabit;
+import connectingstar.tars.habit.request.QuitHabitListRequest;
+import connectingstar.tars.habit.response.QuitHabitListResponse;
+import connectingstar.tars.user.domain.QUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Objects;
+
+import static connectingstar.tars.user.domain.QUser.user;
+
+/**
+ * 종료한 습관 Repository
+ *
+ * @author 김성수
+ */
+
+@RequiredArgsConstructor
+@Repository
+public class QuitHabitDao {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 종료한 습관 조회
+     *
+     * @param param 조회 조건
+     * @return      조회 결과
+     */
+
+    public List<QuitHabitListResponse> getList(QuitHabitListRequest param) {
+        QQuitHabit quitHabit = QQuitHabit.quitHabit;
+        // 타입별 회원이 보유중인 별자리 조회
+            return queryFactory
+                    .select(getConstructorExpression())
+                    .from(quitHabit)
+                    .where(quitHabit.user.Id.eq(param.getUserId()))
+                    .fetch();
+    }
+
+    private ConstructorExpression<QuitHabitListResponse> getConstructorExpression() {
+        QQuitHabit quitHabit = QQuitHabit.quitHabit;
+
+        return Projections.constructor(
+                QuitHabitListResponse.class,
+                quitHabit.quitHabitId,
+                quitHabit.user.Id,
+                quitHabit.user.nickname,
+                quitHabit.runTime,
+                quitHabit.place,
+                quitHabit.action,
+                quitHabit.value,
+                quitHabit.restValue,
+                quitHabit.reasonOfQuit,
+                quitHabit.startDate,
+                quitHabit.quitDate
+        );
+    }
+}

--- a/src/main/java/connectingstar/tars/habit/request/QuitHabitListRequest.java
+++ b/src/main/java/connectingstar/tars/habit/request/QuitHabitListRequest.java
@@ -1,0 +1,19 @@
+package connectingstar.tars.habit.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 내 종료한 습관 조회 요청
+ *
+ * @author 김성수
+ */
+@Getter
+@Setter
+public class QuitHabitListRequest {
+
+    /**
+     * 유저 ID
+     */
+    private Long userId;
+}

--- a/src/main/java/connectingstar/tars/habit/request/RunHabitDeleteRequest.java
+++ b/src/main/java/connectingstar/tars/habit/request/RunHabitDeleteRequest.java
@@ -15,7 +15,7 @@ public class RunHabitDeleteRequest {
     /**
      * 사용자 PK
      */
-    //TODO: USER Entity 추가 후 작성
+    private Long userId;
 
     /**
      * 진행중인 습관 ID

--- a/src/main/java/connectingstar/tars/habit/request/RunHabitPostRequest.java
+++ b/src/main/java/connectingstar/tars/habit/request/RunHabitPostRequest.java
@@ -19,7 +19,7 @@ public class RunHabitPostRequest {
     /**
      * 사용자 PK
      */
-    //TODO: USER Entity 추가 후 작성
+    private Long userId;
 
     /**
      * 정체성

--- a/src/main/java/connectingstar/tars/habit/request/RunHabitPutRequest.java
+++ b/src/main/java/connectingstar/tars/habit/request/RunHabitPutRequest.java
@@ -24,7 +24,7 @@ public class RunHabitPutRequest {
     /**
      * 사용자 PK
      */
-    //TODO: USER Entity 추가 후 작성
+    private Long userId;
 
     /**
      * 정체성

--- a/src/main/java/connectingstar/tars/habit/response/QuitHabitListResponse.java
+++ b/src/main/java/connectingstar/tars/habit/response/QuitHabitListResponse.java
@@ -1,94 +1,94 @@
-package connectingstar.tars.habit.domain;
+package connectingstar.tars.habit.response;
 
-import connectingstar.tars.common.audit.Auditable;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import connectingstar.tars.user.domain.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 /**
- * 종료한 습관 엔티티
+ * 내 종료한 습관 조회 응답
  *
  * @author 김성수
  */
 @Getter
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Access(AccessType.FIELD)
-public class QuitHabit extends Auditable {
+@JsonPropertyOrder({"quitHabitId", "userId","userName", "runTime", "place", "action", "value", "restValue", "reasonOfQuit","startDate", "quitDate"})
+public class QuitHabitListResponse {
 
     /**
      * 종료한 습관 ID
      */
-    @Id
-    @Column(name = "quit_habit_id", nullable = false)
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer quitHabitId;
+    private final Integer quitHabitId;
 
     /**
      * 사용자 PK
      */
-    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST,CascadeType.MERGE} )
-    @JoinColumn(name = "user_id",nullable = false)
-    private User user;
+    private final Long userId;
+
+
+    /**
+     * 사용자 이름
+     */
+    private final String userNickname;
 
     /**
      * 실천 시간
      */
     @Column(name = "run_time", nullable = false)
-    private LocalTime runTime;
+    private final LocalTime runTime;
 
     /**
      * 장소
      */
     @Column(name = "place", nullable = false)
-    private String place;
+    private final String place;
 
     /**
      * 행동
      */
     @Column(name = "action", nullable = false)
-    private String action;
+    private final String action;
 
     /**
      * 실천횟수
      */
     @Column(name = "value", nullable = false)
-    private Integer value;
+    private final Integer value;
 
     /**
      * 휴식 실천횟수
      */
     @Column(name = "rest_value", nullable = false)
-    private Integer restValue;
+    private final Integer restValue;
 
     /**
      * 종료 사유
      */
     @Column(name = "reason_of_quit", nullable = false, length = 400)
-    private String reasonOfQuit;
+    private final String reasonOfQuit;
 
     /**
      * 시작 날짜
      */
     @Column(name = "start_date", nullable = false)
-    private LocalDateTime startDate;
+    private final LocalDateTime startDate;
 
     /**
      * 종료 날짜
      */
     @Column(name = "quit_date", nullable = false)
-    private LocalDateTime quitDate;
+    private final LocalDateTime quitDate;
 
-    @Builder(builderMethodName = "postQuitHabit")
-    public QuitHabit(LocalTime runTime,User user, String place, String action, Integer value, Integer restValue, String reasonOfQuit, LocalDateTime startDate, LocalDateTime quitDate) {
+    public QuitHabitListResponse(Integer quitHabitId, Long userId, String userNickname, LocalTime runTime,
+                                 String place, String action, Integer value, Integer restValue, String reasonOfQuit,
+                                 LocalDateTime startDate, LocalDateTime quitDate) {
+        this.quitHabitId = quitHabitId;
+        this.userId = userId;
+        this.userNickname = userNickname;
         this.runTime = runTime;
-        this.user = user;
         this.place = place;
         this.action = action;
         this.value = value;

--- a/src/main/java/connectingstar/tars/habit/response/RunHabitPutResponse.java
+++ b/src/main/java/connectingstar/tars/habit/response/RunHabitPutResponse.java
@@ -16,7 +16,7 @@ import java.time.LocalTime;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"runHabitId", "identity", "runTime", "place", "action", "value", "unit", "firstAlert","secondAlert"})
+@JsonPropertyOrder({"runHabitId", "userId","userName","identity", "runTime", "place", "action", "value", "unit", "firstAlert","secondAlert"})
 public class RunHabitPutResponse {
 
 
@@ -28,7 +28,13 @@ public class RunHabitPutResponse {
     /**
      * 사용자 PK
      */
-    //TODO: USER Entity 추가 후 작성
+    private final Long userId;
+
+
+    /**
+     * 사용자 이름
+     */
+    private final String userNickname;
 
     /**
      * 정체성
@@ -72,6 +78,8 @@ public class RunHabitPutResponse {
 
     public RunHabitPutResponse(RunHabit runHabit,LocalTime firstAlert,LocalTime secondAlert) {
         this.runHabitId = runHabit.getRunHabitId();
+        this.userId = runHabit.getUser().getId();
+        this.userNickname = runHabit.getUser().getNickname();
         this.identity = runHabit.getIdentity();
         this.runTime = runHabit.getRunTime();
         this.place = runHabit.getPlace();

--- a/src/main/java/connectingstar/tars/habit/validation/HabitValidator.java
+++ b/src/main/java/connectingstar/tars/habit/validation/HabitValidator.java
@@ -2,6 +2,8 @@ package connectingstar.tars.habit.validation;
 
 import connectingstar.tars.common.exception.ValidationException;
 import connectingstar.tars.common.exception.errorcode.ErrorCode;
+import connectingstar.tars.common.exception.errorcode.UserErrorCode;
+import connectingstar.tars.habit.request.QuitHabitListRequest;
 import connectingstar.tars.habit.request.RunHabitPostRequest;
 import lombok.experimental.UtilityClass;
 
@@ -28,6 +30,9 @@ public class HabitValidator {
         validateNull(param.getAction(), RUN_HABIT_PARAM_ACTION_EMPTY);
         validateNull(param.getValue(), RUN_HABIT_PARAM_VALUE_EMPTY);
         validateNull(param.getUnit(), RUN_HABIT_PARAM_UNIT_EMPTY);
+    }
+    public void validate(QuitHabitListRequest param) {
+        validateNull(param.getUserId(), UserErrorCode.USER_NOT_FOUND);
     }
 
     private void validateNull(Object param, ErrorCode errorCode) {

--- a/src/main/java/connectingstar/tars/user/domain/User.java
+++ b/src/main/java/connectingstar/tars/user/domain/User.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import connectingstar.tars.habit.domain.HabitHistory;
+import connectingstar.tars.habit.domain.QuitHabit;
+import connectingstar.tars.habit.domain.RunHabit;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,6 +39,17 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<HabitHistory> habitHistories = new ArrayList<>(); //사용자의 습관기록 데이터들
+
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<RunHabit> runHabits = new ArrayList<>(); //사용자가 진행중인 습관들
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<QuitHabit> quitHabits = new ArrayList<>() ; //사용자가 이전에 종료한 습관들
+
 
     /**
      * 보유한 별자리(캐릭터) 목록


### PR DESCRIPTION
UserEntity내부에 habitHistories, runHabits, quitHabits라는 습관 관련 필드들이 추가되었습니다
일대 다로 연관관계 매핑이 되어있습니다

그리고 기존에 CascadeType.REMOVE로 되어있던 필드들에서 REMOVE를 제거했습니다. 해당 기능에 대해 제가 잘못생각하고 잇었습니다.
