### PR TITLE
 Fix: 단일 진행중인 습관 찾기 api,  진행중인 습관 수정 api에 1차, 2차 알림 on/off 여부 필드 추가, …

### DIFF
--- a/src/main/java/connectingstar/tars/habit/command/HabitAlertCommandService.java
+++ b/src/main/java/connectingstar/tars/habit/command/HabitAlertCommandService.java
@@ -39,13 +39,14 @@ public class HabitAlertCommandService {
         }
     }
 
-    public LocalTime updateHabitAlert(LocalTime changeTime, List<HabitAlert> alerts, Integer alertOrder) {
+    public LocalTime updateHabitAlert(LocalTime changeTime, List<HabitAlert> alerts, Integer alertOrder, Boolean alertStatus) {
         HabitAlert habitAlert = alerts
                 .stream()
                 .filter(alert -> Objects.equals(alert.getAlertOrder(), alertOrder))
                 .findFirst()
                 .orElseThrow(() -> new ValidationException(ALERT_NOT_FOUND));
         habitAlert.updateAlertTime(changeTime);
+        habitAlert.updateAlertStatus(alertStatus);
         return habitAlert.getAlertTime();
     }
 

--- a/src/main/java/connectingstar/tars/habit/command/HabitHistoryCommandService.java
+++ b/src/main/java/connectingstar/tars/habit/command/HabitHistoryCommandService.java
@@ -82,7 +82,7 @@ public class HabitHistoryCommandService {
         Optional<HabitHistory> recentHistory = user.getHabitHistories()
                 .stream()
                 .filter(habitHistory -> Objects.equals(habitHistory.getRunHabit().getRunHabitId(), param.getRunHabitId()))
-                .filter(habitHistory -> LocalDate.now().minusDays(2).isAfter(habitHistory.getRunDate().toLocalDate()))
+                .filter(habitHistory -> param.getReferenceDate().isEqual(habitHistory.getRunDate().toLocalDate()))
                 .sorted(Comparator.comparingInt(HabitHistory::getHabitHistoryId).reversed())
                 .findFirst();
         if (recentHistory.isPresent()) {

--- a/src/main/java/connectingstar/tars/habit/controller/HabitController.java
+++ b/src/main/java/connectingstar/tars/habit/controller/HabitController.java
@@ -81,6 +81,31 @@ public class HabitController {
     }
 
     /**
+     * 내 진행중인 당일 습관 조회
+     *
+     * @param param 진행중인 습관 ID, 기준 날짜
+     * @return 배열(종료한 습관 ID, 사용자 PK, 사용자 이름, 실천 시간, 장소, 행동, 실천횟수, 휴식 실천횟수, 종료 사유, 시작 날짜, 종료 날짜)
+     */
+    @GetMapping(value = "/day")
+    public ResponseEntity<?> doGetRunDay(RunGetRequest param) {
+        HabitValidator.validate(param);
+        return ResponseEntity.ok(new DataResponse(runHabitQueryService.getDay(param)));
+    }
+
+    /**
+     * 내 이번주 매일 습관 전체 작성여부 확인 **쿼리에 매우 문제가 많음(N+1문제) 추후 반드시 수정이 필요함
+     *
+     * @param param 진행중인 습관 ID, 기준 날짜
+     * @return 배열(기준 날짜, 습관기록 전체 작성 여부)
+     */
+    @GetMapping(value = "/history/week-total-write")
+    public ResponseEntity<?> doGetHistoryTotalWrite(RunGetRequest param) {
+        HabitValidator.validate(param);
+        return ResponseEntity.ok(new DataResponse(runHabitQueryService.getHistoryTotalWrite(param)));
+    }
+
+
+    /**
      * 내 종료 습관 조회
      *
      * @return 배열(종료한 습관 ID, 사용자 PK, 사용자 이름, 실천 시간, 장소, 행동, 실천횟수, 휴식 실천횟수, 종료 사유, 시작 날짜, 종료 날짜)

--- a/src/main/java/connectingstar/tars/habit/domain/HabitAlert.java
+++ b/src/main/java/connectingstar/tars/habit/domain/HabitAlert.java
@@ -64,4 +64,9 @@ public class HabitAlert {
     public void updateAlertTime(LocalTime alertTime) {
         this.alertTime = alertTime != null ? alertTime : this.alertTime;
     }
+
+    public void updateAlertStatus(Boolean alertStatus) {
+        if(alertStatus == null) return;
+        this.alertStatus = alertStatus;
+    }
 }

--- a/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
+++ b/src/main/java/connectingstar/tars/habit/domain/RunHabit.java
@@ -108,13 +108,22 @@ public class RunHabit extends Auditable {
         this.alerts.add(habitAlert);
     }
 
-    public void updateData(RunPutRequest param) {
-        this.identity = param.getIdentity() != null ? param.getIdentity() : this.identity;
+    public void updateData(RunPutRequest param, User user) {
+        this.identity = checkIdentity(user, param.getIdentity());
         this.runTime = param.getRunTime() != null ? param.getRunTime().toLocalTime() : this.runTime;
         this.place = param.getPlace() != null ? param.getPlace() : this.place;
         this.action = param.getBehavior() != null ? param.getBehavior() : this.action;
         this.value = param.getBehaviorValue() != null ? param.getBehaviorValue() : this.value;
         this.unit = param.getBehaviorUnit() != null ? param.getBehaviorUnit() : this.unit;
+    }
+
+    private String checkIdentity(User user, String paramIdentity) {
+        if (paramIdentity != null && user.getRunHabits().stream().anyMatch(rh -> rh.getIdentity().equals(paramIdentity)))
+            return paramIdentity;
+        else {
+            return this.identity;
+        }
+
 
     }
 }

--- a/src/main/java/connectingstar/tars/habit/query/RunHabitQueryService.java
+++ b/src/main/java/connectingstar/tars/habit/query/RunHabitQueryService.java
@@ -3,14 +3,24 @@ package connectingstar.tars.habit.query;
 import static connectingstar.tars.common.exception.errorcode.HabitErrorCode.RUN_HABIT_NOT_FOUND;
 
 import connectingstar.tars.common.exception.ValidationException;
+import connectingstar.tars.habit.domain.HabitHistory;
 import connectingstar.tars.habit.domain.RunHabit;
+import connectingstar.tars.habit.repository.HabitHistoryRepository;
+import connectingstar.tars.habit.repository.RunHabitDao;
 import connectingstar.tars.habit.repository.RunHabitRepository;
 import connectingstar.tars.habit.request.RunGetRequest;
+import connectingstar.tars.habit.response.HabitGetHome2Response;
+import connectingstar.tars.habit.response.HabitGetHomeResponse;
 import connectingstar.tars.habit.response.RunGetListResponse;
 import connectingstar.tars.habit.response.RunPutResponse;
 import connectingstar.tars.user.command.UserHabitCommandService;
 import connectingstar.tars.user.domain.User;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +38,8 @@ import java.util.stream.Collectors;
 public class RunHabitQueryService {
 
     private final RunHabitRepository runHabitRepository;
+    private final HabitHistoryRepository habitHistoryRepository;
+    private final RunHabitDao runHabitDao;
     private final UserHabitCommandService userHabitCommandService;
 
     /**
@@ -58,4 +70,56 @@ public class RunHabitQueryService {
             .findFirst().orElseThrow(() -> new ValidationException(RUN_HABIT_NOT_FOUND));
     }
 
+    public HabitGetHomeResponse getDay(RunGetRequest param) {
+        //이전 일자에 대해선 오늘기준으로 월~ 일의 데이터를 전달 -> 모든 습관이 존재할경우 true, false
+        //오늘의 습관 다 꺼내옴 -> 만약 해빗 히스토리가 없는 경우 -> 기록가능 ->0
+        User userByUserId = userHabitCommandService.findUserByUserId();
+        RunHabit runHabit = userByUserId.getRunHabits()
+            .stream()
+            .filter(rh -> rh.getRunHabitId().equals(param.getRunHabitId())).findFirst()
+            .orElseThrow(() -> new ValidationException(RUN_HABIT_NOT_FOUND));
+        Optional<HabitHistory> first = runHabit.getHabitHistories().stream()
+            .filter(hh -> hh.getRunDate().toLocalDate().isEqual(param.getReferenceDate())).findFirst();
+        Integer habitStatus = 0;
+        if(first.isEmpty()) {
+            //해빗 히스토리가 없는 경우 -> 오늘의 날짜와 조회한 date가 2일 이상 차이나는 경우 -> 기록 불가 -> 1
+            if (param.getReferenceDate().isBefore(LocalDate.now().minusDays(2))) {
+                habitStatus = 1;
+                return new HabitGetHomeResponse(runHabit, habitStatus);
+            }
+            return new HabitGetHomeResponse(runHabit, habitStatus);
+        }
+        // 해빗 히스토리가 있는 경우 -> 만약 습관 status? 가 0이 아닐경우 -> 오늘 실천 완료 -> 2
+        HabitHistory habitHistory = first.get();
+        if(habitHistory.getAchievement() != 0 ){
+            habitStatus = 2;
+            return new HabitGetHomeResponse(runHabit,habitStatus);
+        }
+        // 해빗 히스토리가 있는경우 -> status가 0일경우  -> 오늘 휴식 -> 3
+        return new HabitGetHomeResponse(runHabit, habitStatus);
+    }
+
+    public List<HabitGetHome2Response> getHistoryTotalWrite(RunGetRequest param){
+        User userByUserId = userHabitCommandService.findUserByUserId();
+        int size = userByUserId.getRunHabits().size();
+        LocalDate referenceDate = param.getReferenceDate();
+        LocalDate thisWeekSunday = referenceDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        LocalDate startDay = thisWeekSunday.atStartOfDay().toLocalDate();
+        List<HabitGetHome2Response> responses = new ArrayList<>();
+        int count = 1;
+      while (count <= 7) {
+          HabitGetHome2Response habitGetHome2Response = new HabitGetHome2Response(startDay,
+              checkTodayAllHabitHistoryCreate(startDay, userByUserId, size));
+          responses.add(habitGetHome2Response);
+          startDay = startDay.plusDays(1);
+          count++;
+      }
+      return responses;
+    }
+
+    private boolean checkTodayAllHabitHistoryCreate(LocalDate referenceDate, User user, Integer runHabitSize){
+        List<RunHabit> list = user.getRunHabits().stream()
+            .filter(rh -> rh.getHabitHistories().stream().anyMatch(hh -> hh.getRunDate().toLocalDate().isEqual(referenceDate))).toList();
+        return list.size() == runHabitSize;
+    }
 }

--- a/src/main/java/connectingstar/tars/habit/repository/HabitHistoryDao.java
+++ b/src/main/java/connectingstar/tars/habit/repository/HabitHistoryDao.java
@@ -12,6 +12,7 @@ import connectingstar.tars.habit.domain.QRunHabit;
 import connectingstar.tars.habit.request.HistoryCreateCheckRequest;
 import connectingstar.tars.habit.request.HistoryGetListRequest;
 import connectingstar.tars.habit.request.HistoryListRequest;
+import connectingstar.tars.habit.request.RunGetRequest;
 import connectingstar.tars.habit.response.HistoryCreateCheckResponse;
 import connectingstar.tars.habit.response.HistoryGetListResponse;
 import connectingstar.tars.habit.response.HistoryListResponse;
@@ -128,6 +129,7 @@ public class HabitHistoryDao {
                 .where(getPredicate(param, habitHistory, startDateTime, endDateTime))
                 .fetch();
     }
+
 
     public HistoryCreateCheckResponse getCheckTodayCreate(HistoryCreateCheckRequest param) {
         QUser user = QUser.user;

--- a/src/main/java/connectingstar/tars/habit/repository/HabitHistoryRepository.java
+++ b/src/main/java/connectingstar/tars/habit/repository/HabitHistoryRepository.java
@@ -1,7 +1,11 @@
 package connectingstar.tars.habit.repository;
 
 import connectingstar.tars.habit.domain.HabitHistory;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HabitHistoryRepository extends JpaRepository<HabitHistory,Integer> {
+
+  List<HabitHistory> findHabitHistoriesByUserIdAndRunDate(Integer userId, LocalDateTime runDate);
 }

--- a/src/main/java/connectingstar/tars/habit/repository/RunHabitDao.java
+++ b/src/main/java/connectingstar/tars/habit/repository/RunHabitDao.java
@@ -5,10 +5,15 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import connectingstar.tars.common.exception.ValidationException;
 import connectingstar.tars.common.utils.UserUtils;
+import connectingstar.tars.habit.domain.QHabitHistory;
 import connectingstar.tars.habit.domain.QRunHabit;
 import connectingstar.tars.habit.domain.RunHabit;
+import connectingstar.tars.habit.request.RunGetRequest;
 import connectingstar.tars.habit.request.RunListRequest;
+import connectingstar.tars.habit.response.HabitGetHomeResponse;
+import connectingstar.tars.habit.response.HistoryListResponse;
 import connectingstar.tars.habit.response.RunPutResponse;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -43,6 +48,7 @@ public class RunHabitDao {
                 .where(runHabit.user.id.eq(param.getUserId()))
                 .fetch();
     }
+
 
     /**
      * 진행중인 습관 해당유저 소유여부 확인

--- a/src/main/java/connectingstar/tars/habit/request/RunGetRequest.java
+++ b/src/main/java/connectingstar/tars/habit/request/RunGetRequest.java
@@ -14,4 +14,10 @@ public class RunGetRequest {
    */
   private Integer runHabitId;
 
+  /**
+   * 조회 기준 날짜
+   */
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+  private LocalDate referenceDate;
+
 }

--- a/src/main/java/connectingstar/tars/habit/request/RunPutRequest.java
+++ b/src/main/java/connectingstar/tars/habit/request/RunPutRequest.java
@@ -60,7 +60,17 @@ public class RunPutRequest {
     private TimeInfo firstAlert;
 
     /**
+     * 1차 알림 상태값
+     */
+    private Boolean firstAlertStatus;
+
+    /**
      * 2차 알림 (값이 없을 시 자동으로 runTime 30분 후로 설정)
      */
     private TimeInfo secondAlert;
+
+    /**
+     * 2차 알림 상태값
+     */
+    private Boolean secondAlertStatus;
 }

--- a/src/main/java/connectingstar/tars/habit/response/HabitGetHome2Response.java
+++ b/src/main/java/connectingstar/tars/habit/response/HabitGetHome2Response.java
@@ -1,0 +1,29 @@
+package connectingstar.tars.habit.response;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import connectingstar.tars.common.domain.TimeInfo;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class HabitGetHome2Response {
+
+  /**
+   * 기준날짜
+   */
+
+  private final LocalDate referenceDate;
+
+  /**
+   * 습관전체 작성여부
+   */
+
+  private final boolean todayWrite;
+
+  public HabitGetHome2Response(LocalDate referenceDate, boolean todayWrite) {
+    this.referenceDate = referenceDate;
+    this.todayWrite = todayWrite;
+  }
+}

--- a/src/main/java/connectingstar/tars/habit/response/HabitGetHomeResponse.java
+++ b/src/main/java/connectingstar/tars/habit/response/HabitGetHomeResponse.java
@@ -6,34 +6,17 @@ import connectingstar.tars.common.domain.TimeInfo;
 import connectingstar.tars.habit.domain.HabitHistory;
 import connectingstar.tars.habit.domain.RunHabit;
 import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.jetbrains.annotations.NotNull;
-
-
-/**
- * 진행중인 습관 수정 응답
- *
- * @author 김성수
- */
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"runHabitId", "userId", "userNickname", "identity", "runTime", "place", "behavior", "behaviorValue", "behaviorUnit","historyInfo"})
-public class RunGetListResponse {
+@JsonPropertyOrder({"runHabitId", "userNickname", "identity", "runTime", "place", "behavior", "behaviorValue", "behaviorUnit", "habitStatus"})
+public class HabitGetHomeResponse {
 
   /**
    * 진행중인 습관 ID
    */
   private final Integer runHabitId;
-
-  /**
-   * 사용자 PK
-   */
-  private final Integer userId;
-
 
   /**
    * 사용자 이름
@@ -71,21 +54,25 @@ public class RunGetListResponse {
   private final String behaviorUnit;
 
   /**
-   * 습관 기록 정보 (일주일)
+   * 단위
    */
-  private final List<HistoryInfo> historyInfo;
+  private final Integer habitStatus;
 
-  private @NotNull List<HistoryInfo> getList(RunHabit runHabit) {
-    return runHabit.getHabitHistories()
-        .stream()
-        .filter(hh -> hh.getRunDate().toLocalDate().isAfter(LocalDate.now().minusDays(7)))
-        .map(HistoryInfo::new)
-        .toList();
+
+  public HabitGetHomeResponse(Integer runHabitId, String userNickname, String identity, TimeInfo runTime, String place, String behavior,
+      Integer behaviorValue, String behaviorUnit, Integer habitStatus) {
+    this.runHabitId = runHabitId;
+    this.userNickname = userNickname;
+    this.identity = identity;
+    this.runTime = runTime;
+    this.place = place;
+    this.behavior = behavior;
+    this.behaviorValue = behaviorValue;
+    this.behaviorUnit = behaviorUnit;
+    this.habitStatus = habitStatus;
   }
-
-  public RunGetListResponse(RunHabit runHabit) {
+  public HabitGetHomeResponse(RunHabit runHabit, Integer habitStatus) {
     this.runHabitId = runHabit.getRunHabitId();
-    this.userId = runHabit.getUser().getId();
     this.userNickname = runHabit.getUser().getNickname();
     this.identity = runHabit.getIdentity();
     this.runTime = new TimeInfo(runHabit.getRunTime());
@@ -93,18 +80,6 @@ public class RunGetListResponse {
     this.behavior = runHabit.getAction();
     this.behaviorValue = runHabit.getValue();
     this.behaviorUnit = runHabit.getUnit();
-    this.historyInfo = getList(runHabit);
-  }
-
-  @Getter
-  public static class HistoryInfo {
-    private final LocalDate runDate;
-    private final Integer status;
-
-
-    public HistoryInfo(HabitHistory habitHistory) {
-      this.runDate = habitHistory.getRunDate().toLocalDate();
-      this.status = habitHistory.getAchievement();
-    }
+    this.habitStatus = habitStatus;
   }
 }

--- a/src/main/java/connectingstar/tars/habit/response/RunPutResponse.java
+++ b/src/main/java/connectingstar/tars/habit/response/RunPutResponse.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"runHabitId", "userId", "userName", "identity", "runTime", "place", "action", "value", "unit", "firstAlert", "secondAlert","historyInfo"})
+@JsonPropertyOrder({"runHabitId", "userId", "userName", "identity", "runTime", "place", "action", "value", "unit", "firstAlert", "firstAlertStatus", "secondAlert", "secondAlertStatus"})
 public class RunPutResponse {
 
 
@@ -76,23 +76,20 @@ public class RunPutResponse {
     private final TimeInfo firstAlert;
 
     /**
+     * 1차 알림 상태
+     */
+    private final Boolean firstAlertStatus;
+
+
+    /**
      * 2차 알림
      */
     private final TimeInfo secondAlert;
 
-    public RunPutResponse(RunHabit runHabit, LocalTime firstAlert, LocalTime secondAlert) {
-        this.runHabitId = runHabit.getRunHabitId();
-        this.userId = runHabit.getUser().getId();
-        this.userNickname = runHabit.getUser().getNickname();
-        this.identity = runHabit.getIdentity();
-        this.runTime = new TimeInfo(runHabit.getRunTime());
-        this.place = runHabit.getPlace();
-        this.behavior = runHabit.getAction();
-        this.behaviorValue = runHabit.getValue();
-        this.behaviorUnit = runHabit.getUnit();
-        this.firstAlert = new TimeInfo(firstAlert);
-        this.secondAlert = new TimeInfo(secondAlert);
-    }
+    /**
+     * 2차 알림 상태
+     */
+    private final Boolean secondAlertStatus;
 
     public RunPutResponse(RunHabit runHabit) {
         this.runHabitId = runHabit.getRunHabitId();
@@ -105,6 +102,9 @@ public class RunPutResponse {
         this.behaviorValue = runHabit.getValue();
         this.behaviorUnit = runHabit.getUnit();
         this.firstAlert = new TimeInfo(runHabit.getAlerts().get(0).getAlertTime());
+        this.firstAlertStatus = runHabit.getAlerts().get(0).getAlertStatus();
         this.secondAlert = new TimeInfo(runHabit.getAlerts().get(1).getAlertTime());
+        this.secondAlertStatus = runHabit.getAlerts().get(1).getAlertStatus();
+
     }
 }

--- a/src/main/java/connectingstar/tars/user/command/UserCommandService.java
+++ b/src/main/java/connectingstar/tars/user/command/UserCommandService.java
@@ -25,6 +25,7 @@ import connectingstar.tars.user.response.UserBasicInfoAndHabitResponse;
 import connectingstar.tars.user.response.UserBasicInfoResponse;
 import connectingstar.tars.user.response.UserStarResponse;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,9 +63,9 @@ public class UserCommandService {
    */
   public UserBasicInfoResponse getUserBasicInfo() {
     User getUser = userQueryService.getUser();
-    RunHabit firstRunHabit = getUser.getRunHabits().stream().filter(runHabit -> getUser.getIdentity().equals(runHabit.getIdentity()))
-        .findFirst().orElseThrow(() -> new ValidationException(USER_IDENTITY_NOT_FOUNT));
-    return new UserBasicInfoResponse(getUser, firstRunHabit);
+    Optional<RunHabit> first = getUser.getRunHabits().stream().filter(runHabit -> getUser.getIdentity().equals(runHabit.getIdentity()))
+        .findFirst();
+    return first.map(runHabit -> new UserBasicInfoResponse(getUser, runHabit)).orElseGet(() -> new UserBasicInfoResponse(getUser));
   }
 
   /**

--- a/src/main/java/connectingstar/tars/user/response/UserBasicInfoResponse.java
+++ b/src/main/java/connectingstar/tars/user/response/UserBasicInfoResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import connectingstar.tars.common.domain.TimeInfo;
 import connectingstar.tars.habit.domain.RunHabit;
 import connectingstar.tars.user.domain.User;
+import java.time.LocalTime;
 import lombok.Getter;
 
 @Getter
@@ -82,5 +83,20 @@ public class UserBasicInfoResponse {
     this.behaviorUnit = runHabit.getUnit();
     this.firstAlert = new TimeInfo(runHabit.getAlerts().get(0).getAlertTime());
     this.secondAlert = new TimeInfo(runHabit.getAlerts().get(1).getAlertTime());
+  }
+
+  public UserBasicInfoResponse(User user) {
+    this.nickname = user.getNickname();
+    this.genderType = user.getGender().getCode();
+    this.ageRangeType = user.getAgeRange().getCode();
+    this.referrer = user.getReferrer();
+    this.identity = user.getIdentity();
+    this.runTime = new TimeInfo(LocalTime.now());
+    this.place = "기본장소";
+    this.behavior = "기본행동";
+    this.behaviorValue = 0;
+    this.behaviorUnit = "기본단위";
+    this.firstAlert = new TimeInfo(LocalTime.now());
+    this.secondAlert = new TimeInfo(LocalTime.now());
   }
 }


### PR DESCRIPTION
…홈화면에 사용할 당일 습관 조회, 매일 습관 전체 작성여부 확인하는 API 추가, 만약 습관이 없을경우 탬플릿 대표습관 생성후 전달, 습관 삭제시 해당 정체성과 대표정체성이 일치할 경우 다른 습관의 정체성으로 변경(없을시 습관탬플릿 작성), 습관에 없는 정체성은 변경불가

추가적으로 작성한 습관 전체작성여부 확인 api의 쿼리성능이 좋지 않습니다... 수정이 필요한 부분 인지하고 있으며 시간날때 변경하도록하겠습니다...