### PR TITLE
Feature: history POST 요청에 공통 DTO 적용

### DIFF
--- a/src/main/java/connectingstar/tars/habit/command/HabitHistoryCommandService.java
+++ b/src/main/java/connectingstar/tars/habit/command/HabitHistoryCommandService.java
@@ -40,7 +40,8 @@ public class HabitHistoryCommandService {
     private final HabitHistoryMapper habitHistoryMapper;
 
     /**
-     * 습관기록 저장
+     * 습관 기록 저장.
+     * 휴식이 아닌 기록을 저장합니다. 휴식 기록 저장은 `saveRestHistory`에서 처리.
      *
      * @param param 진행중인 습관 ID, 만족도, 실천한 장소, 실천량, 느낀점
      */
@@ -68,7 +69,7 @@ public class HabitHistoryCommandService {
                 .runValue(param.getBehaviorValue())
                 .achievement(param.getAchievement())
                 .review(param.getReview())
-                .isRest(param.getAchievement() == REST_VALUE)
+                .isRest(false)
                 .build();
 
         HabitHistory savedHistory = habitHistoryRepository.save(habitHistory);

--- a/src/main/java/connectingstar/tars/habit/controller/HabitController.java
+++ b/src/main/java/connectingstar/tars/habit/controller/HabitController.java
@@ -47,7 +47,8 @@ public class HabitController {
     }
 
     /**
-     * 습관 기록 생성
+     * 습관 기록 생성.
+     * 휴식이 아닌 습관 기록을 생성합니다. 휴식 기록은 `/habit/history/rest` 에서 생성.
      * TODO: 별이 쌓여야 하는데 안 되어 있음
      *
      * @param param 습관 기록을 저장하기 위한 유저 ID, 진행중인 습관 ID, 만족도, 실천한 장소, 실천량, 느낀점, 휴식여부
@@ -59,6 +60,11 @@ public class HabitController {
         HabitHistoryPostResponse savedHistoryResponse = habitHistoryCommandService.saveHistory(param);
         return ResponseEntity.ok(new DataResponse(savedHistoryResponse));
     }
+
+//    public ResponseEntity<?> doPostHistoryRest(@RequestBody HabitHistoryRestPostRequest param) {
+//        HabitHistoryRestPostResponse savedHistoryResponse = habitHistoryCommandService.saveRestHistory(param);
+//        return ResponseEntity.ok(new DataResponse(savedHistoryResponse));
+//    }
 
     /**
      * 내 진행중인 습관 조회 (*임시 추후 고치겠습니다)

--- a/src/main/java/connectingstar/tars/habit/domain/HabitHistory.java
+++ b/src/main/java/connectingstar/tars/habit/domain/HabitHistory.java
@@ -84,11 +84,9 @@ public class HabitHistory extends Auditable {
 
     /**
      * 휴식 여부
-     * 성수님께서 더 이상 사용하지 않는다고 하심
-     * value = rest_value로 활용
      * <p>
-     * 준식님(프론트엔드)에서 필요없다고 하심
-     * achievement 0으로 표현
+     * ! 기존 코드에서 휴식을 achievement = 0으로 처리했음.
+     * ! 현 로직에서는 achievement 값과 관련 없이 isRest=true를 휴식으로 처리하므로 발견하면 수정할 것.
      */
     @Column(name = "is_rest", nullable = false)
     private Boolean isRest;

--- a/src/main/java/connectingstar/tars/habit/dto/HabitHistoryDto.java
+++ b/src/main/java/connectingstar/tars/habit/dto/HabitHistoryDto.java
@@ -1,0 +1,70 @@
+package connectingstar.tars.habit.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 습관 기록 단일 정보를 저장하는 DTO.
+ * 관련 엔티티 정보는 id만 포함.
+ *
+ * @author 이우진
+ */
+@Getter
+@Setter
+public class HabitHistoryDto {
+    /**
+     * 생성된 습관 기록 ID
+     */
+    private Integer habitHistoryId;
+
+    /**
+     * 기록을 생성한 사용자 ID
+     */
+    private Integer userId;
+
+    /**
+     * 습관 ID
+     */
+    private Integer runHabitId;
+
+    /**
+     * 실천한 날짜, 시간
+     */
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime runDate;
+
+    /**
+     * 실천한 장소
+     */
+    private String runPlace;
+
+    /**
+     * 액션
+     * (책 읽기를)
+     */
+    private String action;
+
+    /**
+     * 실천량
+     */
+    private Integer runValue;
+
+    /**
+     * 만족도
+     * 표정 이미지로 표현됨
+     */
+    private Integer achievement;
+
+    /**
+     * 느낀점
+     */
+    private String review;
+
+    /**
+     * 휴식 여부
+     */
+    private Boolean isRest;
+}

--- a/src/main/java/connectingstar/tars/habit/mapper/HabitHistoryMapper.java
+++ b/src/main/java/connectingstar/tars/habit/mapper/HabitHistoryMapper.java
@@ -1,6 +1,7 @@
 package connectingstar.tars.habit.mapper;
 
 import connectingstar.tars.habit.domain.HabitHistory;
+import connectingstar.tars.habit.dto.HabitHistoryDto;
 import connectingstar.tars.habit.response.HabitHistoryPostResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -10,7 +11,10 @@ import org.mapstruct.factory.Mappers;
 public interface HabitHistoryMapper {
     HabitHistoryMapper INSTANCE = Mappers.getMapper(HabitHistoryMapper.class);
 
+    @Mapping(source = "habitHistory", target = "habitHistory")
+    HabitHistoryPostResponse toPostResponse(HabitHistory habitHistory);
+
     @Mapping(source = "user.id", target = "userId")
     @Mapping(source = "runHabit.runHabitId", target = "runHabitId")
-    HabitHistoryPostResponse toPostResponse(HabitHistory habitHistory);
+    HabitHistoryDto toDto(HabitHistory habitHistory);
 }

--- a/src/main/java/connectingstar/tars/habit/response/HabitHistoryPostResponse.java
+++ b/src/main/java/connectingstar/tars/habit/response/HabitHistoryPostResponse.java
@@ -1,10 +1,8 @@
 package connectingstar.tars.habit.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import connectingstar.tars.habit.dto.HabitHistoryDto;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
 
 /**
  * 습관 기록 생성 후 response DTO
@@ -15,55 +13,7 @@ import java.time.LocalDateTime;
 @Setter
 public class HabitHistoryPostResponse {
     /**
-     * 생성된 습관 기록 ID
+     * 생성된 습관 기록
      */
-    private Integer habitHistoryId;
-
-    /**
-     * 기록을 생성한 사용자 ID
-     */
-    private Integer userId;
-
-    /**
-     * 습관 ID
-     */
-    private Integer runHabitId;
-
-    /**
-     * 실천한 날짜, 시간
-     */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
-    private LocalDateTime runDate;
-
-    /**
-     * 실천한 장소
-     */
-    private String runPlace;
-
-    /**
-     * 액션
-     * (책 읽기를)
-     */
-    private String action;
-
-    /**
-     * 실천량
-     */
-    private Integer runValue;
-
-    /**
-     * 만족도
-     * 표정 이미지로 표현됨
-     */
-    private Integer achievement;
-
-    /**
-     * 느낀점
-     */
-    private String review;
-
-    /**
-     * 휴식 여부
-     */
-    private Boolean isRest;
+    private HabitHistoryDto habitHistory;
 }


### PR DESCRIPTION
- /habit/history POST 요청에 공통 DTO 적용
  - 추후 휴식 api에서 재사용하기 위해
- `habitHistory.isRest = true`를 휴식 상태로 적용하기 위해 로직 변경
  - 기존: `achievement = 0`이 휴식이었음
  - `achievement`와 휴식이 같은 값을 사용하면 버그가 발생할 우려가 있어서 준식님과 상의 후 변경