### PR TITLE
Fix: [HB-219] (history) get list sort order bug

### DIFF
--- a/src/main/java/connectingstar/tars/common/request/param/SortRequestParam.java
+++ b/src/main/java/connectingstar/tars/common/request/param/SortRequestParam.java
@@ -16,5 +16,5 @@ public interface SortRequestParam<ESortBy extends Enum> {
      *
      * @return "asc", "desc"
      */
-    SortOrder getOrder();
+    SortOrder getSortOrder();
 }

--- a/src/main/java/connectingstar/tars/habit/query/QuitHabitQueryService.java
+++ b/src/main/java/connectingstar/tars/habit/query/QuitHabitQueryService.java
@@ -58,7 +58,7 @@ public class QuitHabitQueryService {
                         requestParam.getPage(),
                         requestParam.getSize(),
                         requestParam.getSortBy(),
-                        conversionService.convert(requestParam.getOrder(), Order.class)
+                        conversionService.convert(requestParam.getSortOrder(), Order.class)
                 );
 
         return QuitHabitGetListResponse.builder()

--- a/src/main/java/connectingstar/tars/habit/request/QuitHabitGetListRequestParam.java
+++ b/src/main/java/connectingstar/tars/habit/request/QuitHabitGetListRequestParam.java
@@ -18,5 +18,5 @@ public class QuitHabitGetListRequestParam implements PaginationRequestParam, Sor
     // Sort
     private QuitHabitSortBy sortBy;
 
-    private SortOrder order;
+    private SortOrder sortOrder;
 }

--- a/src/main/java/connectingstar/tars/history/query/HabitHistoryQueryService.java
+++ b/src/main/java/connectingstar/tars/history/query/HabitHistoryQueryService.java
@@ -98,7 +98,7 @@ public class HabitHistoryQueryService {
                 requestParam.getPage(),
                 requestParam.getSize(),
                 requestParam.getSortBy(),
-                conversionService.convert(requestParam.getOrder(), Order.class)
+                conversionService.convert(requestParam.getSortOrder(), Order.class)
         );
 
         return HistoryGetListResponse.builder()

--- a/src/main/java/connectingstar/tars/history/request/HistoryGetListRequestParam.java
+++ b/src/main/java/connectingstar/tars/history/request/HistoryGetListRequestParam.java
@@ -42,7 +42,7 @@ public class HistoryGetListRequestParam implements PaginationRequestParam, SortR
     /**
      * ("asc" | "desc")
      */
-    private SortOrder order = SortOrder.DESC;
+    private SortOrder sortOrder = SortOrder.DESC;
 
     // Related
     /**


### PR DESCRIPTION
- `sortOrder` param 이름이 문서와 달라서 동작하지 않는 문제 수정