### PR TITLE
Feature: [HB-224] 통계 페이지 api 추가

### DIFF
--- a/src/main/java/connectingstar/tars/common/request/param/ExpandRequestParam.java
+++ b/src/main/java/connectingstar/tars/common/request/param/ExpandRequestParam.java
@@ -10,11 +10,11 @@ import java.util.List;
  *
  * @author 이우진
  */
-public interface ExpandRequestParam {
+public interface ExpandRequestParam<EExpand extends Enum> {
     /**
      * 추가로 조회할 필드 목록
      * request param에 추가하지 않으면 이 필드 목록은 조회하지 않습니다.
      */
     @Nullable
-    List<String> getExpand();
+    List<EExpand> getExpand();
 }

--- a/src/main/java/connectingstar/tars/common/request/param/RelatedRequestParam.java
+++ b/src/main/java/connectingstar/tars/common/request/param/RelatedRequestParam.java
@@ -6,11 +6,11 @@ import java.util.List;
  * 조회 API - 관련 데이터(JOIN) 조회 시 사용할 때 쓰는 Request Param 속성.
  * related로 요청 시에만 해당 필드를 JOIN하는 방식으로 설계하여 성능을 최적화한다.
  */
-public interface RelatedRequestParam {
+public interface RelatedRequestParam<ERelated extends Enum> {
     /**
      * 같이 조회할(JOIN) 속성명
      *
      * @return null, 조회할 속성명
      */
-    List<String> getRelated();
+    List<ERelated> getRelated();
 }

--- a/src/main/java/connectingstar/tars/habit/controller/HabitController.java
+++ b/src/main/java/connectingstar/tars/habit/controller/HabitController.java
@@ -56,18 +56,6 @@ public class HabitController {
     }
 
     /**
-     * 내 습관 1개 조회
-     */
-    @GetMapping("/{runHabitId}")
-    public ResponseEntity<DataResponse<HabitGetOneResponse>> getOne(
-            @PathVariable Integer runHabitId,
-            @ModelAttribute @Valid HabitGetOneRequestParam requestParam
-    ) {
-        HabitGetOneResponse responseDto = runHabitQueryService.getMineById(runHabitId, requestParam);
-        return ResponseEntity.ok(new DataResponse(responseDto));
-    }
-
-    /**
      * 날짜를 입력받아 해당 날짜의 습관, 기록, 상태를 조회한다.
      * 홈 페이지 - 캘린더 - 날짜별 습관 수행을 조회할 때 사용한다.
      */
@@ -76,6 +64,18 @@ public class HabitController {
             @ModelAttribute @Valid HabitDailyTrackingRequestParam requestParam
     ) {
         List<HabitDailyTrackingGetResponse> responseDto = runHabitQueryService.getDailyTrackingList(requestParam);
+        return ResponseEntity.ok(new DataResponse(responseDto));
+    }
+
+    /**
+     * 내 습관 1개 조회
+     */
+    @GetMapping("/{runHabitId}")
+    public ResponseEntity<DataResponse<HabitGetOneResponse>> getOne(
+            @PathVariable Integer runHabitId,
+            @ModelAttribute @Valid HabitGetOneRequestParam requestParam
+    ) {
+        HabitGetOneResponse responseDto = runHabitQueryService.getMineById(runHabitId, requestParam);
         return ResponseEntity.ok(new DataResponse(responseDto));
     }
 
@@ -107,6 +107,21 @@ public class HabitController {
             @Valid @RequestBody HabitDeleteRequest request
     ) {
         HabitDeleteResponse response = runHabitCommandService.deleteMineById(runHabitId, request);
+
+        return ResponseEntity.ok(new DataResponse(response));
+    }
+
+    /**
+     * 습관 1개의 통계를 조회합니다.
+     * <p>
+     * 누적 별, 누적 실천량
+     * [FU-37] 통계 페이지에서 사용
+     */
+    @GetMapping("/{runHabitId}/statistics")
+    public ResponseEntity<DataResponse<HabitGetOneStatisticsResponse>> getStatistics(
+            @PathVariable Integer runHabitId
+    ) {
+        HabitGetOneStatisticsResponse response = runHabitQueryService.getMyStatisticsById(runHabitId);
 
         return ResponseEntity.ok(new DataResponse(response));
     }

--- a/src/main/java/connectingstar/tars/habit/enums/RunHabitSortBy.java
+++ b/src/main/java/connectingstar/tars/habit/enums/RunHabitSortBy.java
@@ -1,0 +1,5 @@
+package connectingstar.tars.habit.enums;
+
+public enum RunHabitSortBy {
+    CREATED_AT
+}

--- a/src/main/java/connectingstar/tars/habit/query/RunHabitQueryService.java
+++ b/src/main/java/connectingstar/tars/habit/query/RunHabitQueryService.java
@@ -62,7 +62,9 @@ public class RunHabitQueryService {
      *
      * @return 진행중인 습관 수정을 위한 사용자 PK, 정체성, 실천 시간, 장소, 행동, 얼마나, 단위, 1차 알림시각, 2차 알림시각 (추후 고치겠습니다 지금 시간이 없어서 ㅠ)
      * TODO: 리턴값 수정
+     * @deprecated use .getMyList() instead.
      */
+    @Deprecated
     public List<RunGetListResponse> getList() {
 
         List<RunHabit> allByUser = runHabitRepository.findAllByUser(userHabitCommandService.findUserByUserId());
@@ -74,7 +76,9 @@ public class RunHabitQueryService {
      *
      * @return 진행중인 습관 수정을 위한 사용자 PK, 정체성, 실천 시간, 장소, 행동, 얼마나, 단위, 1차 알림시각, 2차 알림시각 (추후 고치겠습니다 지금 시간이 없어서 ㅠ)
      * TODO: 리턴값 수정
+     * @deprecated use .getMineById() instead.
      */
+    @Deprecated
     public RunPutResponse get(RunGetRequest param) {
 
         User userByUserId = userHabitCommandService.findUserByUserId();
@@ -147,10 +151,27 @@ public class RunHabitQueryService {
         User user = userQueryService.getCurrentUserOrElseThrow();
         List<RunHabit> runHabits = runHabitRepository.findAllByUser(user);
 
+        if (requestParam.getSortBy() != null) {
+            runHabits.sort((habit1, habit2) -> {
+                switch (requestParam.getSortBy()) {
+                    case CREATED_AT:
+                        switch (requestParam.getSortOrder()) {
+                            case ASC:
+                            default:
+                                return habit1.getCreatedAt().compareTo(habit2.getCreatedAt());
+                            case DESC:
+                                return habit2.getCreatedAt().compareTo(habit1.getCreatedAt());
+                        }
+                    default:
+                        return 0;
+                }
+            });
+        }
+
         List<RunHabitDto> dtos = runHabitMapper.toDtoList(runHabits);
 
         if (requestParam.getExpand() != null) {
-            if (requestParam.getExpand().contains("historyCountByStatus")) {
+            if (requestParam.getExpand().contains(HabitGetListRequestParam.Expand.HISTORY_COUNT_BY_STATUS)) {
                 dtos.forEach(dto -> {
                     Integer completedHistoryCount = habitHistoryRepository.countByRunHabit_RunHabitIdAndIsRest(dto.getRunHabitId(), false);
                     Integer restHistoryCount = habitHistoryRepository.countByRunHabit_RunHabitIdAndIsRest(dto.getRunHabitId(), true);

--- a/src/main/java/connectingstar/tars/habit/request/param/HabitGetListRequestParam.java
+++ b/src/main/java/connectingstar/tars/habit/request/param/HabitGetListRequestParam.java
@@ -1,6 +1,9 @@
 package connectingstar.tars.habit.request.param;
 
+import connectingstar.tars.common.enums.SortOrder;
 import connectingstar.tars.common.request.param.ExpandRequestParam;
+import connectingstar.tars.common.request.param.SortRequestParam;
+import connectingstar.tars.habit.enums.RunHabitSortBy;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
@@ -9,12 +12,22 @@ import java.util.List;
 
 @Getter
 @Setter
-public class HabitGetListRequestParam implements ExpandRequestParam {
+public class HabitGetListRequestParam implements ExpandRequestParam, SortRequestParam {
+    // expand
+    public enum Expand {
+        HISTORY_COUNT_BY_STATUS
+    }
+
     /**
      * 추가로 요청할 필드 목록
      *
      * @returns "historyCountByStatus"
      */
     @Nullable
-    private List<String> expand;
+    private List<Expand> expand;
+
+    // sort
+    RunHabitSortBy sortBy = RunHabitSortBy.CREATED_AT;
+
+    SortOrder sortOrder = SortOrder.ASC;
 }

--- a/src/main/java/connectingstar/tars/habit/response/HabitGetOneStatisticsResponse.java
+++ b/src/main/java/connectingstar/tars/habit/response/HabitGetOneStatisticsResponse.java
@@ -1,0 +1,20 @@
+package connectingstar.tars.habit.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class HabitGetOneStatisticsResponse {
+    /**
+     * 누적 획득 별
+     */
+    private Integer totalStarCount = 0;
+
+    /**
+     * 누적 실천량
+     */
+    private Integer totalValue = 0;
+}

--- a/src/main/java/connectingstar/tars/history/command/HabitHistoryCommandService.java
+++ b/src/main/java/connectingstar/tars/history/command/HabitHistoryCommandService.java
@@ -47,9 +47,10 @@ public class HabitHistoryCommandService {
      */
     public static final int HISTORY_CREATION_PERIOD_DAYS = 1;
     /**
-     * 실천 기록 생성 보상 별 개수
+     * 실천 기록 생성 보상 별 개수.
+     * 휴식 기록은 제외.
      */
-    public static final int HISTORY_CREATION_REWARD_STAR_COUNT = 1;
+    public static final int COMPLETED_HISTORY_CREATION_REWARD_STAR_COUNT = 1;
 
     private final HabitHistoryRepository habitHistoryRepository;
     private final RunHabitRepository runHabitRepository;
@@ -98,7 +99,7 @@ public class HabitHistoryCommandService {
         HabitHistory savedHistory = habitHistoryRepository.save(habitHistory);
 
         // [FU-24] 실천 기록 보상 별 부여
-        userCommandService.addStar(user.getId(), HISTORY_CREATION_REWARD_STAR_COUNT);
+        userCommandService.addStar(user.getId(), COMPLETED_HISTORY_CREATION_REWARD_STAR_COUNT);
 
         return habitHistoryMapper.toPostResponse(savedHistory);
     }

--- a/src/main/java/connectingstar/tars/history/query/HabitHistoryQueryService.java
+++ b/src/main/java/connectingstar/tars/history/query/HabitHistoryQueryService.java
@@ -112,7 +112,7 @@ public class HabitHistoryQueryService {
                 .build();
     }
 
-    private List<String> toJoinFields(List<String> related) {
+    private List<String> toJoinFields(List<HistoryGetListRequestParam.Related> related) {
         if (related == null) {
             return null;
         }
@@ -121,7 +121,7 @@ public class HabitHistoryQueryService {
                 .map(
                         relatedField -> {
                             switch (relatedField) {
-                                case "runHabit":
+                                case RUN_HABIT:
                                     return "runHabit";
                                 default:
                                     return null;

--- a/src/main/java/connectingstar/tars/history/query/HabitHistoryQueryService.java
+++ b/src/main/java/connectingstar/tars/history/query/HabitHistoryQueryService.java
@@ -94,6 +94,7 @@ public class HabitHistoryQueryService {
         List<HabitHistory> habitHistories = habitHistoryRepositoryCustom.findByRunHabitIdAndIsRest(
                 requestParam.getRunHabitId(),
                 requestParam.getIsRest(),
+                requestParam.getRunDate(),
                 toJoinFields(requestParam.getRelated()),
                 requestParam.getPage(),
                 requestParam.getSize(),

--- a/src/main/java/connectingstar/tars/history/repository/HabitHistoryRepositoryCustom.java
+++ b/src/main/java/connectingstar/tars/history/repository/HabitHistoryRepositoryCustom.java
@@ -12,6 +12,7 @@ import connectingstar.tars.history.domain.HabitHistory;
 import connectingstar.tars.history.enums.HabitHistorySortBy;
 import jakarta.annotation.Nullable;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -31,6 +32,9 @@ public interface HabitHistoryRepositoryCustom {
     /**
      * 습관 id와 휴식 여부로 습관 기록을 조회합니다.
      *
+     * @param runHabitId 습관 id
+     * @param isRest     휴식 여부
+     * @param runDate    조회할 날짜 범위. [startDate, endDate]
      * @param joinFields ("runHabit" | null) 조인할 필드. Fetch join 수행
      * @param offset     Pagination
      * @param limit      Pagination
@@ -39,6 +43,7 @@ public interface HabitHistoryRepositoryCustom {
     public List<HabitHistory> findByRunHabitIdAndIsRest(
             Integer runHabitId,
             @Nullable Boolean isRest,
+            @Nullable List<LocalDate> runDate,
             @Nullable List<String> joinFields,
             @Nullable Integer offset,
             @Nullable Integer limit,

--- a/src/main/java/connectingstar/tars/history/repository/HabitHistoryRepositoryCustomImpl.java
+++ b/src/main/java/connectingstar/tars/history/repository/HabitHistoryRepositoryCustomImpl.java
@@ -24,7 +24,9 @@ import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,6 +54,7 @@ public class HabitHistoryRepositoryCustomImpl implements HabitHistoryRepositoryC
     public List<HabitHistory> findByRunHabitIdAndIsRest(
             Integer runHabitId,
             @Nullable Boolean isRest,
+            @Nullable List<LocalDate> runDate,
             @Nullable List<String> joinFields,
             @Nullable Integer offset,
             @Nullable Integer limit,
@@ -68,6 +71,11 @@ public class HabitHistoryRepositoryCustomImpl implements HabitHistoryRepositoryC
 
         if (isRest != null) {
             whereExpression = whereExpression.and(habitHistory.isRest.eq(isRest));
+        }
+
+        if (runDate != null) {
+            whereExpression = whereExpression.and(
+                    habitHistory.runDate.between(runDate.get(0).atStartOfDay(), runDate.get(1).atTime(LocalTime.MAX)));
         }
 
         query = query.where(whereExpression);

--- a/src/main/java/connectingstar/tars/history/request/HistoryGetListRequestParam.java
+++ b/src/main/java/connectingstar/tars/history/request/HistoryGetListRequestParam.java
@@ -5,10 +5,13 @@ import connectingstar.tars.common.request.param.PaginationRequestParam;
 import connectingstar.tars.common.request.param.RelatedRequestParam;
 import connectingstar.tars.common.request.param.SortRequestParam;
 import connectingstar.tars.history.enums.HabitHistorySortBy;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -17,7 +20,17 @@ public class HistoryGetListRequestParam implements PaginationRequestParam, SortR
     /**
      * 연결된 습관 id
      */
+    @NotNull
     private Integer runHabitId;
+
+    /**
+     * 조회할 날짜 범위.
+     * [startDate, endDate] 형식.
+     * 시작 날짜와 끝 날짜 모두 포함한 데이터 반환.
+     */
+    @Nullable
+    @Size(min = 2, max = 2, message = "날짜 범위는 startDate, endDate 2개여야 합니다.")
+    List<LocalDate> runDate;
 
     /**
      * 휴식 기록 여부

--- a/src/main/java/connectingstar/tars/history/request/HistoryGetListRequestParam.java
+++ b/src/main/java/connectingstar/tars/history/request/HistoryGetListRequestParam.java
@@ -58,8 +58,13 @@ public class HistoryGetListRequestParam implements PaginationRequestParam, SortR
     private SortOrder sortOrder = SortOrder.DESC;
 
     // Related
+
+    public enum Related {
+        RUN_HABIT
+    }
+
     /**
      * ("runHabit")[] | null
      */
-    private List<String> related = null;
+    private List<Related> related = null;
 }

--- a/src/test/java/connectingstar/tars/habit/query/RunHabitQueryServiceTest.java
+++ b/src/test/java/connectingstar/tars/habit/query/RunHabitQueryServiceTest.java
@@ -1,0 +1,89 @@
+package connectingstar.tars.habit.query;
+
+import connectingstar.tars.habit.domain.RunHabit;
+import connectingstar.tars.habit.repository.RunHabitRepository;
+import connectingstar.tars.habit.response.HabitGetOneStatisticsResponse;
+import connectingstar.tars.history.command.HabitHistoryCommandService;
+import connectingstar.tars.history.domain.HabitHistory;
+import connectingstar.tars.user.domain.User;
+import connectingstar.tars.user.query.UserQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RunHabitQueryServiceTest {
+
+    @Mock
+    private UserQueryService userQueryService;
+
+    @Mock
+    private RunHabitRepository runHabitRepository;
+
+    @Mock
+    private HabitHistoryCommandService habitHistoryCommandService;
+
+    @InjectMocks
+    private RunHabitQueryService runHabitQueryService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getMyStatisticsByIdReturnsCorrectStatistics() {
+        User user = mock(User.class);
+        Integer runHabitId = 1;
+        RunHabit runHabit = mock(RunHabit.class);
+        HabitHistory habitHistory1 = mock(HabitHistory.class);
+        HabitHistory habitHistory2 = mock(HabitHistory.class);
+        HabitHistory restHistory = mock(HabitHistory.class);
+
+        when(userQueryService.getCurrentUserOrElseThrow()).thenReturn(user);
+        when(runHabitRepository.findByRunHabitId(runHabitId)).thenReturn(Optional.ofNullable(runHabit));
+        when(runHabit.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn(1);
+
+        when(runHabit.getHabitHistories()).thenReturn(List.of(habitHistory1, habitHistory2));
+        when(habitHistory1.getIsRest()).thenReturn(false);
+        when(habitHistory2.getIsRest()).thenReturn(false);
+        when(restHistory.getIsRest()).thenReturn(true);
+        when(habitHistory1.getRunValue()).thenReturn(10);
+        when(habitHistory2.getRunValue()).thenReturn(20);
+        when(restHistory.getRunValue()).thenReturn(null);
+
+        HabitGetOneStatisticsResponse response = runHabitQueryService.getMyStatisticsById(runHabitId);
+
+        // completed: 2, rest: 1
+        assertEquals(2 * 1 + 0 * 1, response.getTotalStarCount());
+        assertEquals(10 + 20, response.getTotalValue());
+    }
+
+    @Test
+    void getMyStatisticsByIdReturnsZeroWhenNoHistories() {
+        User user = mock(User.class);
+        Integer runHabitId = 1;
+        RunHabit runHabit = mock(RunHabit.class);
+
+        when(userQueryService.getCurrentUserOrElseThrow()).thenReturn(user);
+        when(runHabitRepository.findByRunHabitId(runHabitId)).thenReturn(Optional.ofNullable(runHabit));
+        when(runHabit.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn(1);
+
+        when(runHabit.getHabitHistories()).thenReturn(List.of());
+
+        HabitGetOneStatisticsResponse response = runHabitQueryService.getMyStatisticsById(runHabitId);
+
+        assertEquals(0, response.getTotalStarCount());
+        assertEquals(0, response.getTotalValue());
+    }
+}


### PR DESCRIPTION
## [변경] 습관 목록 조회

`/v2/habits`

(1) 습관 스크롤 탭 영역

### Request Parameter

**sort**

- `sortBy`
    - `"createdAt"`
    - Default: `"createdAt"`
- `sortOrder`
    - `"asc" | "desc"`
    - Default: `"asc"`

## 습관 통계 조회

`/v2/habits/:runHabitId/statistics`

(2) 누적 별

(3) 누적 실천량

### Response body

```jsx
{
	totalStarCount: Integer,
	totalValue: Integer
}
```

## [변경] 습관 기록 조회

`/v2/histories`

(5) 주간 실천 카운트

(6) 통계 그래프 (만족도)

### Request Parameter

- `runDate`
    - `시작_날짜, 끝_날짜` 형식
    - ex) `2023-12-31,2024-01-06`
    - 시작 날짜와 끝 날짜 모두 포함한 데이터 반환. `[start, end]`
- `runHabitId`
    - 습관 id

**sort**

- `sortBy`
    - `"runDate"`
    - Default: `"runDate"`
- `sortOrder`
    - `"asc" | "desc"`
    - Default: `"desc"`
    - 날짜 순서대로 받으려면 `"asc"` 로 호출해 주세요

**pagination**

- `size`
    - `Integer`
    - Default: `20`
    - 페이지 당 불러올 데이터 개수
    - **월간 기록 조회할 때는 `31` 로 호출해 주세요**